### PR TITLE
TypeError: only 0-dimensional arrays can be converted to Python scalars

### DIFF
--- a/physXAI/models/models.py
+++ b/physXAI/models/models.py
@@ -283,7 +283,7 @@ class SingleStepModel(AbstractModel, ABC):
                 current_val = X[b, 0, index]
                 current_true_val = current_val
                 for t in range(X.shape[1]):
-                    pred = float(model.predict(X[b, t, :].reshape(1, -1)))
+                    pred = model.predict(X[b, t, :].reshape(1, -1)).item()
                     if delta_prediction:
                         current_val += pred
                         current_true_val += y[b, t, 0]


### PR DESCRIPTION
# Pull Request

## Description
Fixes Bug: TypeError: only 0-dimensional arrays can be converted to Python scalars


## Type of Change
<!-- Check relevant boxes with [x] -->
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Required Checklist

### Testing
- [ ] Unit tests have been created/updated for new/modified functionality
- [x] CI/CD pipeline passes all tests (pytest, coverage, executables, installation)

### Examples
- [ ] Add examples for new features and functionality

### Compatibility
- [x] Changes are backward compatible OR deprecation warnings added
- [x] No breaking changes to public APIs
- [ ] New dependencies added to `pyproject.toml` (required in `dependencies` or optional in `[project.optional-dependencies]`)

### Documentation
- [ ] Docstrings added/updated for new/modified public methods (Google style)
- [ ] Type hints added for new functions/methods

## Breaking Changes
<!-- If "Breaking change" checked above, describe impact and migration path -->

## Optional

### GitHub Copilot Review
<!-- Request a review from GitHub Copilot to get AI-powered feedback on your changes -->
- [x] Request Copilot review via GitHub UI (add 'copilot' as a reviewer)
